### PR TITLE
Drop explicit command from kspan container for flexibility

### DIFF
--- a/charts/kspan/Chart.yaml
+++ b/charts/kspan/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspan
 description: Install and configure kspan
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.1.1
 keywords:
   - kspan

--- a/charts/kspan/templates/deployment.yaml
+++ b/charts/kspan/templates/deployment.yaml
@@ -31,8 +31,6 @@ spec:
           {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /manager
           {{- with .Values.args }}
           args:
           {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
The `command: /manager` should be unnecessary here, as puckpuck/kspan
has `entrypoint: /manager` already. And by not specifying it, we allow
ghcr.io/ismith/kspan to work. (Its entrypoint is /ko-app/kspan; we use
github.com/google/ko to build a multiarch image, and ko doesn't let us
specify the entrypoint.)