### PR TITLE
Update cluster-role.yaml

### DIFF
--- a/charts/kspan/templates/cluster-role.yaml
+++ b/charts/kspan/templates/cluster-role.yaml
@@ -11,6 +11,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes
       - endpoints
       - events
       - pods


### PR DESCRIPTION
Adds permission to view nodes resources to resolve the following runtime errors:

```
2021-11-17T18:58:59.931Z        ERROR   dropping span   {"name": "5afd4e4b-cf82-4b84-b6b5-9a1acfb98ef3", "error": "unable to get object: nodes \"ip-10-228-43-130.us-west-2.compute.internal\" is forbidden: User \"system:serviceaccount:monitoring:kspan\" cannot get resource \"nodes\" in API group \"\" at the cluster scope", "errorVerbose": "nodes \"ip-10-228-43-130.us-west-2.compute.internal\" is forbidden: User \"system:serviceaccount:monitoring:kspan\" cannot get resource \"nodes\" in API group \"\" at the cluster scope\nunable to get object\ngithub.com/weaveworks-experiments/kspan/controllers/events.getObject\n\t/workspace/controllers/events/object.go:127\ngithub.com/weaveworks-experiments/kspan/controllers/events.(*EventWatcher).makeSpanContextFromEvent\n\t/workspace/controllers/events/pending.go:102\ngithub.com/weaveworks-experiments/kspan/controllers/events.(*EventWatcher).checkOlderPending\n\t/workspace/controllers/events/pending.go:66\ngithub.com/weaveworks-experiments/kspan/controllers/events.(*EventWatcher).runTicker\n\t/workspace/controllers/events/event_controller.go:306\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371"}
```